### PR TITLE
🔒 [security] Replace innerHTML with replaceChildren in src/casino.js

### DIFF
--- a/src/casino.js
+++ b/src/casino.js
@@ -15,7 +15,7 @@ var centerX;
 var finished = false;
 
 function assignLanguage() {
-  document.getElementById('consonDiv').innerHTML = '';
+  document.getElementById('consonDiv').replaceChildren();
   width = window.innerWidth;
   height = window.innerHeight;
   vowelLetters = vowelLetterLangs[currentLang][0];

--- a/tests/casino.test.js
+++ b/tests/casino.test.js
@@ -52,6 +52,7 @@ const sandbox = {
     document: {
         getElementById: () => ({
             innerHTML: '',
+            replaceChildren: () => {},
             appendChild: () => {},
             selectedIndex: 0
         }),


### PR DESCRIPTION
### 🎯 What
Fixed a potential security vulnerability by replacing the use of `innerHTML` for clearing DOM element content with the safer `replaceChildren()` method.

### ⚠️ Risk
Assigning values to `innerHTML` can expose the application to Cross-Site Scripting (XSS) if the data being assigned is untrusted. Although the current use case only assigned an empty string, replacing it with a non-parsing API is a security best practice that prevents future misuse and satisfies security scanners.

### 🛡️ Solution
Used the modern `replaceChildren()` method to clear the content of the `consonDiv` element. This method is efficient and avoids the security risks associated with the HTML parser used by `innerHTML`. The unit tests were also updated to mock the new method, ensuring continued test coverage and correctness.

---
*PR created automatically by Jules for task [3981867209791593019](https://jules.google.com/task/3981867209791593019) started by @nsdevaraj*